### PR TITLE
# 13 add to generator a new function CallOnMaster

### DIFF
--- a/internal/pkg/generator/tmpl/octopus/main.tmpl
+++ b/internal/pkg/generator/tmpl/octopus/main.tmpl
@@ -167,6 +167,14 @@ func (obj {{ $PublicStructName }}Params) PK() string {
 }
 
 func Call(ctx context.Context{{ if ne $procInLen 0 }}, params {{ $PublicStructName }}Params{{ end }}) (*{{ $PublicStructName }}, error) {
+    return call(ctx, params, activerecord.ReplicaOrMasterInstanceType)
+}
+
+func CallOnMaster(ctx context.Context{{ if ne $procInLen 0 }}, params {{ $PublicStructName }}Params{{ end }}) (*{{ $PublicStructName }}, error) {
+    return call(ctx, params, activerecord.MasterInstanceType)
+}
+
+func call(ctx context.Context{{ if ne $procInLen 0 }}, params {{ $PublicStructName }}Params{{ end }}, instanceType activerecord.ShardInstanceType) (*{{ $PublicStructName }}, error) {
 	logger := activerecord.Logger()
 	ctx = logger.SetLoggerValueToContext(ctx, map[string]interface{}{"LuaProc": procName})
 	metricTimer := activerecord.Metric().Timer("octopus", "{{ $PublicStructName }}")
@@ -174,7 +182,7 @@ func Call(ctx context.Context{{ if ne $procInLen 0 }}, params {{ $PublicStructNa
 
     metricTimer.Timing(ctx, "call_proc")
 
-	connection, err := octopus.Box(ctx, 0, activerecord.ReplicaInstanceType, "arcfg", nil)
+	connection, err := octopus.Box(ctx, 0, instanceType, "arcfg", nil)
 	if err != nil {
 		metricErrCnt.Inc(ctx, "call_proc_preparebox", 1)
 		logger.Error(ctx, fmt.Sprintf("Error get box '%s'", err))


### PR DESCRIPTION
При генерации добавлена еще одна версия функции CallOnMaster для вызова процедуры на мастер ноде, текущая функция Call вызывает процедуру на реплике, если реплик нет, то на мастере
Решили с @Nikolo выбор где запускать процедуру должен быть из бизнес логике, в конфигурации процедур делать не надо, лучше указывать явно при вызове