### PR TITLE
fix metadata unpacker for field

### DIFF
--- a/internal/pkg/generator/tmpl/meta.tmpl
+++ b/internal/pkg/generator/tmpl/meta.tmpl
@@ -33,6 +33,7 @@ func (ns NSPackage) meta(n uint32) (SpaceMeta, bool) {
 {{ $nss := .Namespaces }}
 var NamespacePackages = NSPackage {
 {{ range $_, $ns := $nss -}}
+    {{ $serializers := $ns.SerializerMap -}}
     "{{ $ns.Namespace.ObjectName }}": {
         PackageName: "{{ $ns.Namespace.PackageName }}",
         Unpacker: func(ctx context.Context, tuple octopus.TupleData) (any, error) { 
@@ -45,9 +46,21 @@ var NamespacePackages = NSPackage {
         },
         Fields: []FieldMeta{
             {{- range $_, $field := $ns.Fields }}
+            {{ $sname := $field.Serializer.Name }}
             {
                 Name: "{{ $field.Name }}",
-                Unpacker: func(packedField []byte) (any, error){ return {{ $ns.Namespace.PackageName }}.Unpack{{ $field.Name }}(bytes.NewReader(packedField)) },
+                Unpacker: func(packedField []byte) (any, error){
+                    {{ if ne $sname "" -}}
+                    field, err :=  {{ $ns.Namespace.PackageName }}.Unpack{{ $field.Name }}(bytes.NewReader(packedField))
+                    if err != nil {
+                        return nil, err
+                    }
+
+                    return {{ $ns.Namespace.PackageName }}.Marshal{{ $field.Name }}(field)
+                    {{- else }}
+                    return {{ $ns.Namespace.PackageName }}.Unpack{{ $field.Name }}(bytes.NewReader(packedField))
+                    {{- end }}
+                },
             },
             {{- end }}
         },
@@ -144,11 +157,6 @@ func (n NSPackage) formatUpdateMockFixture(ns uint32, spacemeta SpaceMeta, prima
 		val, err := spacemeta.Fields[op.Field].Unpacker(op.Value)
 		if err != nil {
 			val = fmt.Sprintf("% X (can't unpack: %s)", op.Value, err)
-		}
-
-		jsonRaw, err := json.Marshal(val)
-		if err == nil {
-			val = string(jsonRaw)
 		}
 
 		updateFields += fmt.Sprintf("%s %s <= `%v`; ", octopus.GetOpCodeName(op.Op), spacemeta.Fields[op.Field].Name, val)

--- a/internal/pkg/generator/tmpl/octopus/main.tmpl
+++ b/internal/pkg/generator/tmpl/octopus/main.tmpl
@@ -449,6 +449,17 @@ func NewFromBox(ctx context.Context, tuples []octopus.TupleData) ([]*{{ $PublicS
 	{{ if ne $sname "" -}}
 		{{ $serializer := index $serializers $sname -}}
 		{{ $rtype = $serializer.Type -}}
+func Marshal{{ $fstruct.Name }}({{ $fstruct.Name }} {{ $rtype }}) (any, error) {
+    {{ $serparams := $fstruct.Serializer.Params -}}
+    {{ $bvar :=  $packerparam.PackConvFunc $fstruct.Name -}}
+    pvar, err := {{ $serializer.ImportName }}.{{ $serializer.Marshaler }}({{ $serparams }}{{ $bvar }})
+    if err != nil {
+        return nil, fmt.Errorf("error marshal field {{ $fstruct.Name }}: %w", err)
+    }
+
+    return pvar, nil
+}
+
 	{{ end -}}
 func pack{{ $fstruct.Name }}(w []byte, {{ $fstruct.Name }} {{ $rtype }}) ([]byte, error) {
 	{{ $bvar :=  $packerparam.PackConvFunc $fstruct.Name -}}


### PR DESCRIPTION
При выводе вставляемых полей и полей фикстуры  отображались значения полученные сериализатором  отличным от установленного для конкретного поля, которые вводили в заблуждение
 
Возможность распаковка полей репозитория с учетом заданного для поля  типа сериализатора. Используется при отладочном выводе моксервера. Нужно для того, чтобы была возможность корректно сравнить результат работы логики модификации данных с заданной фикстурой

Для полей у которых заданы сериализаторы в repository.NamespacePackages функция Unpacker выглядела так:
```
Name: "Extra",
Unpacker: func(packedField []byte) (any, error) { return UnpackExtra(bytes.NewReader(packedField) }, // возвращает структуру описанную в декларации
```
Теперь в repository.go будет генерится код
```
Name: "Extra",
Unpacker: func(packedField []byte) (any, error) {
	field, err := promoaction.UnpackExtra(bytes.NewReader(packedField))
	if err != nil {
		return nil, err
	}

	return promoaction.MarshalExtra(field) // возвращает значение, непосредственно сохраняемое в БД
},
```
где функция MarshalExtra сериализует поле в соответствии с заданным для него сериализатором, генерится в octopus.go
```
func MarshalExtra(Extra *ds.PromoactionExtra) (any, error) {
	pvar, err := serializerExtra.MapstructureMarshal(Extra)
	if err != nil {
		return nil, fmt.Errorf("error marshal field Extra: %w", err)
	}

	return pvar, nil
}
```
